### PR TITLE
Adding version header

### DIFF
--- a/code/DNest4.h
+++ b/code/DNest4.h
@@ -1,4 +1,5 @@
 #ifndef DNest4_DNest4
+#define DNest4_DNest4
 
 /*
 * Include every header file in DNest4

--- a/code/DNest4.h
+++ b/code/DNest4.h
@@ -5,6 +5,7 @@
 * Include every header file in DNest4
 */
 
+#include "Version.h"
 #include "Barrier.h"
 #include "CommandLineOptions.h"
 #include "Level.h"

--- a/code/Version.h
+++ b/code/Version.h
@@ -1,0 +1,8 @@
+#ifndef DNest4_Version
+#define DNest4_Version
+
+#define DNEST4_MAJOR_VERSION 0
+#define DNEST4_MINOR_VERSION 1
+#define DNEST4_PATCH_VERSION 0
+
+#endif  // DNest4_Version


### PR DESCRIPTION
We should version DNest4 releases. When you're confident that the version 0.1.0 (for example) is ready, let's create a release on GitHub with the tag `v0.1.0` and try to keep that in sync with the header.
