### PR TITLE
Set output files in OPTIONS

### DIFF
--- a/code/Options.cpp
+++ b/code/Options.cpp
@@ -60,7 +60,14 @@ void Options::load(const char* filename)
 	fin>>max_num_levels;	fin.ignore(1000000, '\n');
 	fin>>lambda;		fin.ignore(1000000, '\n');
 	fin>>beta;		fin.ignore(1000000, '\n');
-	fin>>max_num_saves;
+	fin>>max_num_saves;		fin.ignore(1000000, '\n');
+	fin>>sample_file;		fin.ignore(1000000, '\n');
+	fin>>sample_info_file;	fin.ignore(1000000, '\n');
+	fin>>levels_file;
+
+	if (sample_file.compare("#") == 0) sample_file = "sample.txt";
+	if (sample_info_file.compare("#") == 0) sample_info_file = "sample_info.txt";
+	if (levels_file.compare("#") == 0) levels_file = "levels.txt";
 
 	fin.close();
 

--- a/code/SamplerImpl.h
+++ b/code/SamplerImpl.h
@@ -438,11 +438,11 @@ void Sampler<ModelType>::initialise_output_files() const
 	std::fstream fout;
 
 	// Output headers
-	fout.open("sample_info.txt", std::ios::out);
+	fout.open(options.sample_info_file, std::ios::out);
 	fout<<"# level assignment, log likelihood, tiebreaker, ID."<<std::endl;
 	fout.close();
 
-	fout.open("sample.txt", std::ios::out);
+	fout.open(options.sample_file, std::ios::out);
 	fout<<"# "<<particles[0].description().c_str()<<std::endl;
 	fout.close();
 
@@ -458,7 +458,7 @@ void Sampler<ModelType>::save_levels() const
 
 	// Output file
 	std::fstream fout;
-	fout.open("levels.txt", std::ios::out);
+	fout.open(options.levels_file, std::ios::out);
 	fout<<"# log_X, log_likelihood, tiebreaker, accepts, tries, exceeds, visits";
 	fout<<std::endl;
     fout<<std::setprecision(12);
@@ -486,19 +486,25 @@ void Sampler<ModelType>::save_particle()
 	if(!save_to_disk)
 		return;
 
-	std::cout<<"# Saving particle to disk. N = "<<count_saves<<".";
-	std::cout<<std::endl;
+	//std::cout<<"# Saving particle to disk. N = "<<count_saves<<".";
+	//std::cout<<std::endl;
+
+	if((count_saves) % 10 == 0)
+	{
+		std::cout<<"# Saving particle to disk. N = "<< count_saves <<".";
+		std::cout<<std::endl;
+	}
 
 	// Output file
 	std::fstream fout;
 
 	int which = rngs[0].rand_int(particles.size());
-	fout.open("sample.txt", std::ios::out|std::ios::app);
+	fout.open(options.sample_file, std::ios::out|std::ios::app);
 	particles[which].print(fout);
 	fout<<std::endl;
 	fout.close();
 
-	fout.open("sample_info.txt", std::ios::out|std::ios::app);
+	fout.open(options.sample_info_file, std::ios::out|std::ios::app);
 	fout<<std::setprecision(12);
 
 	fout<<level_assignments[which]<<' ';


### PR DESCRIPTION
This allows me to set the output files in the OPTIONS file, such that I can prefix them with a directory. That way I can run multiple jobs more easily without overwriting the files.
I believe it's backwards compatible for an OPTIONS file like

```
# comment
# comment
2   # Number of particles
1000    # new level interval
50  # save interval
200 # threadSteps
45  # maximum number of levels
45  # Backtracking scale length (lambda in the paper)
70  # Strength of effect to force histogram to equal push
10  # Maximum number of saves (0 = infinite)
(blank line)
```

which outputs to `sample.txt`, `sample_info.txt` and `levels.txt` like normally.

Also works with 

```
# comment
# comment
2   # Number of particles
1000    # new level interval
50  # save interval
200 # threadSteps
45  # maximum number of levels
45  # Backtracking scale length (lambda in the paper)
70  # Strength of effect to force histogram to equal push
10  # Maximum number of saves (0 = infinite)
    # (optional) samples file
    # (optional) sample_info file
    # (optional) levels file
```

again outputs to `sample.txt`, `sample_info.txt` and `levels.txt` like normally.
And with

```
# comment
# comment
2   # Number of particles
1000    # new level interval
50  # save interval
200 # threadSteps
45  # maximum number of levels
45  # Backtracking scale length (lambda in the paper)
70  # Strength of effect to force histogram to equal push
10  # Maximum number of saves (0 = infinite)
somefolder/sample.txt    # (optional) samples file
somefolder/sample_info.txt    # (optional) sample_info file
somefolder/levels.txt    # (optional) levels file
```

where I believe `somefolder` must already exist.

I also reduced the terminal output to every 10 saves but feel free to ignore that.
