### PR TITLE
builder.py: add future statement so the class print method is allowed

### DIFF
--- a/python/dnest4/builder.py
+++ b/python/dnest4/builder.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import numpy as np
 from .distributions import *
 


### PR DESCRIPTION
This is a minor fix that allows the class in builder.py to have a `print()` method when compiled with pythonh2.7. 