### PR TITLE
Move matplotlib imports inside relevant functions

### DIFF
--- a/python/dnest4/analysis.py
+++ b/python/dnest4/analysis.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import matplotlib.pyplot as pl
 
 from .backends import CSVBackend
 
@@ -261,6 +260,7 @@ def make_plots(backend):
 
 
 def make_levels_plot(backend):
+    import matplotlib.pyplot as pl
     fig, ax = pl.subplots(1, 1)
 
     ax.plot(backend.sample_info["level_assignment"], color="k")
@@ -271,6 +271,7 @@ def make_levels_plot(backend):
 
 
 def make_compression_plot(backend):
+    import matplotlib.pyplot as pl
     fig, axes = pl.subplots(2, 1, sharex=True)
 
     levels = backend.levels
@@ -295,6 +296,7 @@ def make_compression_plot(backend):
 
 
 def make_log_X_log_L_plot(backend):
+    import matplotlib.pyplot as pl
     fig, axes = pl.subplots(2, 1, sharex=True)
 
     levels = backend.levels

--- a/python/dnest4/classic.py
+++ b/python/dnest4/classic.py
@@ -1,6 +1,5 @@
 import copy
 import numpy as np
-import matplotlib.pyplot as plt
 from .loading import *
 
 def logsumexp(values):
@@ -34,6 +33,7 @@ def postprocess(temperature=1., numResampleLogX=1, plot=True, loaded=[], \
 	sample_info = sample_info[cut:, :]
 
 	if plot:
+		import matplotlib.pyplot as plt
 		plt.figure(1)
 		plt.plot(sample_info[:,0], "k")
 		plt.xlabel("Iteration")
@@ -242,6 +242,7 @@ compression_scatter=0., moreSamples=1., compression_assert=None, single_precisio
 	sample_info = sample_info[cut:, :]
 
 	if plot:
+		import matplotlib.pyplot as plt
 		plt.figure(1)
 		plt.plot(sample_info[:,0], "k")
 		plt.xlabel("Iteration")
@@ -437,7 +438,7 @@ def diffusion_plot():
 	"""
 	Plot a nice per-particle diffusion plot.
 	"""
-
+	import matplotlib.pyplot as plt
 	sample_info = np.atleast_2d(my_loadtxt('sample_info.txt'))
 	ID = sample_info[:,3].astype('int')
 	j = sample_info[:,0].astype('int')
@@ -456,6 +457,7 @@ def levels_plot():
 	"""
 	Plot the differences between the logl values of the levels.
 	"""
+	import matplotlib.pyplot as plt
 	levels = my_loadtxt('levels.txt')
 
 	plt.plot(np.log10(np.diff(levels[:,1])), "ko-")


### PR DESCRIPTION
Matplotlib can be a pain on some systems, and isn't needed for the sampling itself.

This small change moves the imports of matplotlib inside the functions where it's needed, so that you can import the rest of the code without it.

Cheers,
Joe Zuntz