### PR TITLE
Faster python

### DIFF
--- a/python/dnest4/__init__.py
+++ b/python/dnest4/__init__.py
@@ -14,5 +14,8 @@ if not __DNEST4_SETUP__:
     from .sampler import DNest4Sampler
     from .deprecated import postprocess, postprocess_abc
     from .loading import my_loadtxt, loadtxt_rows
+    from .utils import rand
+    from .utils import randn
     from .utils import randh
     from .utils import wrap
+

--- a/python/dnest4/__init__.py
+++ b/python/dnest4/__init__.py
@@ -16,6 +16,7 @@ if not __DNEST4_SETUP__:
     from .loading import my_loadtxt, loadtxt_rows
     from .utils import rand
     from .utils import randn
+    from .utils import randt2
     from .utils import randh
     from .utils import wrap
 

--- a/python/dnest4/utils.pyx
+++ b/python/dnest4/utils.pyx
@@ -1,21 +1,35 @@
 # -*- coding: utf-8 -*-
-__all__ = ["randh", "wrap"]
+__all__ = ["randh", "wrap", "rand", "new_randh", "randn"]
 
 cimport cython
-from libc.math cimport log, sqrt, abs
-from libc.stdlib cimport rand, RAND_MAX
-import numpy as np
-cimport numpy as np
+from libc.math cimport cos, log, sqrt, abs, M_PI
+from libc.stdlib cimport rand as crand
+from libc.stdlib cimport RAND_MAX
+
+cpdef double rand():
+    """
+    Generate from Uniform(0, 1)
+    """
+    cdef double r = crand()
+    return r/RAND_MAX
+
+cpdef double randn(double mu=0.0, double sigma=1.0):
+    """
+    Generate from normal distribution N(0, 1) using Box-Muller method
+    """
+    cdef double x2pi = 2.0*M_PI*rand()
+    cdef double g2rad = sqrt(-2.0*log(1.0 - rand()))
+    cdef double z = cos(x2pi)*g2rad
+    return mu + z*sigma
 
 cpdef double randh():
     """
     Generate from the heavy-tailed distribution.
     """
-    cdef double a = np.random.randn()
-    cdef double r = rand()
-    cdef double b = r/RAND_MAX
+    cdef double a = randn()
+    cdef double b = rand()
     cdef double t = a/sqrt(-log(b))
-    cdef double n = np.random.randn()
+    cdef double n = randn()
     return pow(10.0, (1.5 - 3*abs(t)))*n
 
 cpdef double wrap(double x, double a, double b):

--- a/python/dnest4/utils.pyx
+++ b/python/dnest4/utils.pyx
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__all__ = ["randh", "wrap", "rand", "new_randh", "randn"]
+__all__ = ["rand", "randn", "randt2", "randh", "wrap"]
 
 cimport cython
 from libc.math cimport cos, log, sqrt, abs, M_PI
@@ -22,15 +22,17 @@ cpdef double randn(double mu=0.0, double sigma=1.0):
     cdef double z = cos(x2pi)*g2rad
     return mu + z*sigma
 
+cpdef double randt2():
+    """
+    Generate from t-distribution with 2 degrees of freedom
+    """
+    return randn()/sqrt(-log(rand()))
+
 cpdef double randh():
     """
     Generate from the heavy-tailed distribution.
     """
-    cdef double a = randn()
-    cdef double b = rand()
-    cdef double t = a/sqrt(-log(b))
-    cdef double n = randn()
-    return pow(10.0, (1.5 - 3*abs(t)))*n
+    return pow(10.0, (1.5 - 3*abs(randt2())))*randn()
 
 cpdef double wrap(double x, double a, double b):
     assert b > a


### PR DESCRIPTION
Updates:
- Removed numpy.random dependency in utils.pyx. dnest.randh is now on par with the Numba version.
- Created callable cython functions: dnest.rand, dnest.randn, dnest.randt2. These should be faster than the numpy.random versions to generate random variates. The ability to create arrays is not allowed.

Notes:
- We should consider putting the random variate generation functions in a dnest.rng module, but this will affect some peoples current codes.
