### PR TITLE
Add gaussian example to C++ Examples (related to #37)

### DIFF
--- a/code/Examples/Gaussian/GaussianExample.cpp
+++ b/code/Examples/Gaussian/GaussianExample.cpp
@@ -1,0 +1,62 @@
+#include "GaussianExample.h"
+#include "DNest4/code/DNest4.h"
+
+using namespace std;
+using namespace DNest4;
+
+GaussianExample::GaussianExample()
+:params(5)
+{
+
+}
+
+double GaussianExample::analytic_log_Z() {
+    return this->params.size() * log(erf(0.5*this->width / sqrt(2))) - this->params.size() * log(this->width);
+}
+
+void GaussianExample::from_prior(RNG& rng)
+{
+    // Sample between -0.5 * width and +0.5 * width
+	for(size_t i=0; i<params.size(); i++) {
+        params[i] = -0.5 * width + width * rng.rand();
+        std::cout << i << " " << params[i] << std::endl;
+    }
+}
+
+double GaussianExample::perturb(RNG& rng)
+{
+    params[coordinate] += width*rng.randh2();
+    wrap(params[coordinate], -0.5*width, 0.5*width);
+    coordinate += 1;
+    coordinate = coordinate % params.size();
+	return 0.0;
+}
+
+double GaussianExample::log_likelihood() const
+{
+    double logL = 0.0;
+
+    for(size_t i=0; i<params.size(); ++i)
+    {
+        logL += params[i] * params[i];
+    }
+
+    logL = -0.5 * logL;
+
+    double constant = -0.5 * log(2* ( std::atan(1)*4  ) // pi
+            );
+    logL = logL + this->params.size() * constant;
+    return logL;
+}
+
+void GaussianExample::print(std::ostream& out) const
+{
+	for(const double& x: params)
+		out<<x<<' ';
+}
+
+string GaussianExample::description() const
+{
+	return string("Each column is one of the 5 parameters.");
+}
+

--- a/code/Examples/Gaussian/GaussianExample.h
+++ b/code/Examples/Gaussian/GaussianExample.h
@@ -1,0 +1,39 @@
+#ifndef DNest4_GaussianExample
+#define DNest4_GaussianExample
+
+#include "DNest4/code/DNest4.h"
+#include <valarray>
+#include <ostream>
+
+class GaussianExample
+{
+	private:
+		std::valarray<double> params;
+		double width = 10;
+		int coordinate = 0;
+
+	public:
+		// Constructor only gives size of params
+		GaussianExample();
+
+		// return analytic solution to log_Z
+		double analytic_log_Z();
+
+		// Generate the point from the prior
+		void from_prior(DNest4::RNG& rng);
+
+		// Metropolis-Hastings proposals
+		double perturb(DNest4::RNG& rng);
+
+		// Likelihood function
+		double log_likelihood() const;
+
+		// Print to stream
+		void print(std::ostream& out) const;
+
+		// Return string with column information
+		std::string description() const;
+};
+
+#endif
+

--- a/code/Examples/Gaussian/Makefile
+++ b/code/Examples/Gaussian/Makefile
@@ -1,0 +1,14 @@
+CXXFLAGS = -std=c++11 -O3 -march=native -Wall -Wextra -pedantic -DNDEBUG
+LIBS = -ldnest4 -lpthread
+
+default:
+	make noexamples -C ../..
+	$(CXX) -I ../../../.. $(CXXFLAGS) -c *.cpp
+	$(CXX) -pthread -L ../.. -o main *.o $(LIBS)
+	rm *.o
+
+nolib:
+	$(CXX) -I ../../../.. $(CXXFLAGS) -c *.cpp
+	$(CXX) -pthread -L ../.. -o main *.o $(LIBS)
+	rm *.o
+

--- a/code/Examples/Gaussian/OPTIONS
+++ b/code/Examples/Gaussian/OPTIONS
@@ -1,0 +1,10 @@
+# File containing parameters for DNest4
+# Put comments at the top, or at the end of the line.
+5       # Number of particles
+10000   # new level interval
+1000  # save interval
+100     # threadSteps - how many steps each thread should do independently before communication
+20     # maximum number of levels
+5      # Backtracking scale length (lambda in the paper)
+100     # Strength of effect to force histogram to equal push (beta in the paper)
+100000  # Maximum number of saves (0 = infinite)

--- a/code/Examples/Gaussian/README.md
+++ b/code/Examples/Gaussian/README.md
@@ -1,0 +1,1 @@
+Demonstration of DNest4 on a model where we know the evidence integral (same as python/examples/gaussian/gaussian.py). 

--- a/code/Examples/Gaussian/main.cpp
+++ b/code/Examples/Gaussian/main.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+#include "DNest4/code/DNest4.h"
+#include "GaussianExample.h"
+
+using namespace DNest4;
+
+int main(int argc, char** argv)
+{
+    RNG::randh_is_randh2 = true;
+	start<GaussianExample>(argc, argv);
+
+
+	std::cout << "Analytical solution: " << GaussianExample().analytic_log_Z() << std::endl;
+
+	return 0;
+}
+

--- a/code/Examples/Gaussian/showresults.py
+++ b/code/Examples/Gaussian/showresults.py
@@ -1,0 +1,18 @@
+import dnest4.classic as dn4
+dn4.postprocess(cut=0.0)
+
+# Plots from the blog post
+import matplotlib.pyplot as plt
+import numpy as np
+
+posterior_sample = dn4.my_loadtxt("posterior_sample.txt")
+plt.plot(posterior_sample[:,41], posterior_sample[:,42],
+         "k.", markersize=1, alpha=0.2)
+plt.xlabel("$x_{41}$")
+plt.ylabel("$x_{42}$")
+plt.show()
+
+plt.imshow(np.corrcoef(posterior_sample.T), cmap="coolwarm",
+           vmin=-1.0, vmax=1.0, interpolation="nearest")
+plt.show()
+


### PR DESCRIPTION
In #37 I opened an issue that the example gaussian.py does not produce a sampled log_Z which is close to the analytical log_Z. In order to further debug this, I added the same example to the C++ version where I get:
```
Analytical solution: -11.5129283315
log(Z) = -11.838912412347822
Information = 4.604287059911951 nats.
Effective sample size = 34762.69919895431
```

When checking the posterior samples everything looks perfect also:
![image](https://user-images.githubusercontent.com/8685531/131335336-6e137f6c-70d8-4cf4-9bc6-b1a696b9e761.png)

So the C++-version seems to work. I will now move on to explicitly check the posteriors for the python example.
I mainly added this so that my code is visible and maybe it will help someone else in the future.
